### PR TITLE
A little more idempotence

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,4 @@ install:
   - pip install ansible
 script:
   - ansible-playbook -i inventory role.yml -e consul_template_bin_path=/home/travis/ -e consul_template_templates_dir=/home/travis/consul-templates
+  - ansible-playbook -i inventory role.yml -e consul_template_bin_path=/home/travis/ -e consul_template_templates_dir=/home/travis/consul-templates | grep -q 'changed=0.*failed=0'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,7 +10,7 @@
     - consul-template
 
 - name: Check consul-template version
-  shell: consul-template --version 2>&1 | grep {{consul_template_ver}}
+  shell: "{{consul_template_bin_path}}/{{consul_template_bin_name}} --version 2>&1 | grep {{consul_template_ver}}"
   failed_when: false
   changed_when: false
   register: consul_template_ver_matches
@@ -25,7 +25,7 @@
 
 - name: Verify binary
   stat:
-    path: "{{consul_template_bin_path}}//{{consul_template_bin_name}}"
+    path: "{{consul_template_bin_path}}/{{consul_template_bin_name}}"
   register: consul_template_verify_binary
   tags:
     - consul-template

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,11 +27,15 @@
   stat:
     path: "{{consul_template_bin_path}}//{{consul_template_bin_name}}"
   register: consul_template_verify_binary
+  tags:
+    - consul-template
 
 - name: Fail if binary is not present
   fail:
     msg: consul-template binary is not present
   when: not consul_template_verify_binary.stat.exists
+  tags:
+    - consul-template
 
 - name: Make templates dir
   file:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,12 +26,12 @@
 - name: Verify binary
   stat:
     path: "{{consul_template_bin_path}}//{{consul_template_bin_name}}"
-  register: verify_binary
+  register: consul_template_verify_binary
 
 - name: Fail if binary is not present
   fail:
     msg: consul-template binary is not present
-  when: not verify_binary.stat.exists
+  when: not consul_template_verify_binary.stat.exists
 
 - name: Make templates dir
   file:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,7 +10,7 @@
     - consul-template
 
 - name: Check consul-template version
-  shell: consul-template --version >> tmp.ver 2>&1 && cat tmp.ver  | grep {{consul_template_ver}}
+  shell: consul-template --version >> tmp.ver 2>&1 && grep {{consul_template_ver}} tmp.ver
   ignore_errors: true
   register: consul_template_ver_matches
   tags:
@@ -23,9 +23,14 @@
     - consul-template
 
 - name: Verify binary
-  shell: "stat {{consul_template_bin_path}}/{{consul_template_bin_name}}"
-  tags:
-    - consul-template
+  stat:
+    path: "{{consul_template_bin_path}}//{{consul_template_bin_name}}"
+  register: verify_binary
+
+- name: Fail if binary is not present
+  fail:
+    msg: consul-template binary is not present
+  when: not verify_binary.stat.exists
 
 - name: Make templates dir
   file:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,15 +10,16 @@
     - consul-template
 
 - name: Check consul-template version
-  shell: consul-template --version >> tmp.ver 2>&1 && grep {{consul_template_ver}} tmp.ver
-  ignore_errors: true
+  shell: consul-template --version 2>&1 | grep {{consul_template_ver}}
+  failed_when: false
+  changed_when: false
   register: consul_template_ver_matches
   tags:
     - consul-template
 
 - name: Install consul-template
   shell: "{{consul_template_install_script}}"
-  when: consul_template_ver_matches|failed
+  when: consul_template_ver_matches.rc != 0
   tags:
     - consul-template
 

--- a/templates/install.j2
+++ b/templates/install.j2
@@ -2,6 +2,7 @@
 #
 # Install consul-template
 #
+set e
 
 pushd {{consul_template_dl_dir}}
 


### PR DESCRIPTION
Minor changes ensuring role idempotence:
- Avoid changed or failed flags when task just checks application version
- Let the installation script fail when an error occurs to avoid unclear later failures
